### PR TITLE
Changed back tip date and carousel items width

### DIFF
--- a/app/assets/stylesheets/components/_carousel.scss
+++ b/app/assets/stylesheets/components/_carousel.scss
@@ -21,7 +21,6 @@
 
 .carousel-item img {
   height: 250px;
-  width: 375px;
   object-fit: cover;
   object-position: center;
 }

--- a/app/views/tips/_tip_section.html.erb
+++ b/app/views/tips/_tip_section.html.erb
@@ -10,8 +10,7 @@
           <% end %>
           <div class="tip-user-info">
             <p class="tip-username"><%= tip.user.username %></p>
-            <%# <p class="tip-date"><%= tip.updated_at.strftime("%B %e, %Y") %>
-            <p class="tip-date"><%= tip.user.climbs.find_by(line: tip.line).climb_date.strftime("%B %e, %Y") %></p>
+            <p class="tip-date"><%= tip.updated_at.strftime("%B %e, %Y") %></p>
           </div>
         </div>
 


### PR DESCRIPTION
Following changes were made (now that the demo is over):

- Displayed tip date is now changed back to last updated date of tip (instead of date of climb logged)
- Took off width restriction on image carousel items on climb show page